### PR TITLE
Chore: Update type definitions for bigInt() in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -119,6 +119,7 @@ declare namespace Blaver {
       hexaDecimal(count?: number): string;
       json(): string;
       array(length?: number): Array<string | number>;
+      bigInt(value?: number): number;
     };
 
     date: {


### PR DESCRIPTION
`index.d.ts` did not contain type definitions for `bigInt()`  function. The type definition has been added.